### PR TITLE
Add pause/resume button for simulation

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ A cool physics and art simulation I created for fun. Good for learning HTML canv
 - **Realistic wall collisions** with momentum preservation
 - **Dynamic color changes** on collisions
 - **Responsive design** that adapts to the window size of your browser/device
+- **Pause/Resume functionality** with interactive button
+- **Speed control** with variable multipliers (0.5x, 1x, 2x)
 
 ## Quick Start
 1. Clone repo:
@@ -25,17 +27,24 @@ A cool physics and art simulation I created for fun. Good for learning HTML canv
 Edit main.js to modify in main.js:
 ```js
 // Change number of balls
-while(balls.length < 30) { // ← Modify this number
+while (balls.length < 30) { // ← Modify this number
 
 // Adjust speed ranges
-random(-7,7) // ← Modify Velocity values
+random(-7, 7) // ← Modify velocity values
 
 // Modify size range
-random(10,20) // ← Modify Ball sizes
+random(10, 20) // ← Modify ball sizes
 
 // Change background fade effect
 ctx.fillStyle = 'rgba(0, 0, 0, 0.25)' // ← Trail effect opacity
+
+// Adjust speed multiplier
+let speedMultiplier = 1; // ← Modify default speed (0.5, 1, 2)
 ```
+
+## Controls
+- Pause/Resume Button: Toggle animation state
+- Speed Button: Cycle through 0.5x, 1x, and 2x speeds
 
 ## Live Demo
 Hosted on GitHub: [Demo Website](https://alicelee2735.github.io/Cosmic-Bouncer/)

--- a/changes.txt
+++ b/changes.txt
@@ -1,75 +1,110 @@
-index.html
-
-    Added a button element below the canvas:
-
-
-    <button id="pauseResumeBtn">Pause</button>
-
-    Added CSS styling for the button:
+New Changes made:
+- Added "Speed control" and "Pause/Resume" to Highlights in README.md
+- Included new controls section for the new buttons
+- Updated Customization section with speed multiplier
+- Suggested additional contribution ideas
 
 
-    button {
-    margin-top: 20px;
-    padding: 10px 20px;
-    font-size: 16px;
-    cursor: pointer;
-    }
 
+#### index.html
+
+Added two button elements below the canvas:
+
+<button id="pauseResumeBtn">Pause</button>
+<button id="speedBtn">Speed: 1x</button>
+
+Added CSS styling for buttons:
+
+button {
+position: absolute;
+bottom: 20px;
+padding: 10px 20px;
+font-size: 16px;
+cursor: pointer;
+background-color: #333;
+color: white;
+border: none;
+border-radius: 5px;
+z-index: 1;
+}
+#pauseResumeBtn {
+left: 20px;
+}
+#speedBtn {
+right: 20px;
+}
 
 main.js
+Added global variables to manage animation state and speed:
 
-    Added global variables to manage the animation state:
+let animationId;
+let isPaused = false;
+let speedMultiplier = 1; // Default speed multiplier
 
+Modified Ball.prototype.update to use speed multiplier:
 
-    let animationId;
-    let isPaused = false;
+this.x += this.velX * speedMultiplier;
+this.y += this.velY * speedMultiplier;
 
+Modified the loop() function to respect the pause state:
 
-    Modified the loop() function to respect the pause state:
+function loop() {
+ctx.fillStyle = 'rgba(0, 0, 0, 0.25)';
+ctx.fillRect(0, 0, width, height);
+while (balls.length < 30) {
+let ball = new Ball(
+random(0, width),
+random(0, height),
+random(-7, 7),
+random(-7, 7),
+randomColor(),
+random(10, 20)
+);
+balls.push(ball);
+}
+for (let i = 0; i < balls.length; i++) {
+let ball = balls[i];
+ball.draw();
+ball.update();
+ball.collisionDetect();
+}
+if (!isPaused) {
+animationId = requestAnimationFrame(loop);
+}
+}
 
+Added a click event listener for pause/resume button:
 
-    function loop() {
-    ctx.fillStyle = 'rgba(0, 0, 0, 0.25)';
-    ctx.fillRect(0, 0, width, height);
-    while (balls.length < 30) {
-        let ball = new Ball(
-            random(0, width),
-            random(0, height),
-            random(-7, 7),
-            random(-7, 7),
-            randomColor(),
-            random(10, 20)
-        );
-        balls.push(ball);
-    }
+document.getElementById('pauseResumeBtn').addEventListener('click', function() {
+isPaused = !isPaused;
+if (isPaused) {
+cancelAnimationFrame(animationId);
+this.textContent = 'Resume';
+} else {
+loop();
+this.textContent = 'Pause';
+}
+});
 
-    for (let i = 0; i < balls.length; i++) {
-        let ball = balls[i];
-        ball.draw();
-        ball.update();
-        ball.collisionDetect();
-    }
+Added a click event listener for speed control button:
 
-    if (!isPaused) {
-        animationId = requestAnimationFrame(loop);
-    }
+document.getElementById('speedBtn').addEventListener('click', function() {
+if (speedMultiplier === 1) {
+speedMultiplier = 0.5;
+this.textContent = 'Speed: 0.5x';
+} else if (speedMultiplier === 0.5) {
+speedMultiplier = 2;
+this.textContent = 'Speed: 2x';
+} else {
+speedMultiplier = 1;
+this.textContent = 'Speed: 1x';
+}
+});
 
-    }
+Additional Improvements:
 
-    Added a click event listener to the button to toggle pause/resume:
+-   Improved code readability with consistent spacing and indentation
+-   Fixed minor formatting issues for better clarity
+-   Added proper positioning for buttons to prevent overlap with canvas
 
-
-    document.getElementById('pauseResumeBtn').addEventListener('click', function() {
-    isPaused = !isPaused;
-    if (isPaused) {
-    cancelAnimationFrame(animationId);
-    this.textContent = 'Resume';
-    } else {
-    loop();
-    this.textContent = 'Pause';
-    }
-    });
-
-
-
-Additionally, I added spaces in some parts of the code for better readability and fixed minor issues to improve clarity and make the code easier to understand.
+I hope you like this changes and helps your project direction ;)

--- a/changes.txt
+++ b/changes.txt
@@ -1,0 +1,75 @@
+index.html
+
+    Added a button element below the canvas:
+
+
+    <button id="pauseResumeBtn">Pause</button>
+
+    Added CSS styling for the button:
+
+
+    button {
+    margin-top: 20px;
+    padding: 10px 20px;
+    font-size: 16px;
+    cursor: pointer;
+    }
+
+
+main.js
+
+    Added global variables to manage the animation state:
+
+
+    let animationId;
+    let isPaused = false;
+
+
+    Modified the loop() function to respect the pause state:
+
+
+    function loop() {
+    ctx.fillStyle = 'rgba(0, 0, 0, 0.25)';
+    ctx.fillRect(0, 0, width, height);
+    while (balls.length < 30) {
+        let ball = new Ball(
+            random(0, width),
+            random(0, height),
+            random(-7, 7),
+            random(-7, 7),
+            randomColor(),
+            random(10, 20)
+        );
+        balls.push(ball);
+    }
+
+    for (let i = 0; i < balls.length; i++) {
+        let ball = balls[i];
+        ball.draw();
+        ball.update();
+        ball.collisionDetect();
+    }
+
+    if (!isPaused) {
+        animationId = requestAnimationFrame(loop);
+    }
+
+    }
+
+    Added a click event listener to the button to toggle pause/resume:
+
+
+    document.getElementById('pauseResumeBtn').addEventListener('click', function() {
+    isPaused = !isPaused;
+    if (isPaused) {
+    cancelAnimationFrame(animationId);
+    this.textContent = 'Resume';
+    } else {
+    loop();
+    this.textContent = 'Pause';
+    }
+    });
+
+
+
+Additionally, I added spaces in some parts of the code for better readability and fixed minor issues to improve clarity and make the code easier to understand.

--- a/index.html
+++ b/index.html
@@ -1,34 +1,52 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <title>Pause/Resume Simulation</title>  
-    <style>
-        body {
-            background-color: black;
-            color: white;
-            font-family: Arial, sans-serif;
-            display: flex;
-            flex-direction: column;
-            align-items: center;
-            justify-content: center;
-            height: 100vh;
-            margin: 0;
-        }
-        canvas {
-            border: 1px solid white;
-        }
-        button {
-            margin-top: 20px;
-            padding: 10px 20px;
-            font-size: 16px;
-            cursor: pointer;
-        }
-    </style>
-</head>
-<body>
-    <canvas></canvas>
-    <button id="pauseResumeBtn">Pause</button>
-    <script src="main.js"></script>
-</body>
+    <head>
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <title>Cosmic Bouncer</title>
+        <style>
+            body {
+                background-color: black;
+                color: white;
+                font-family: Arial, sans-serif;
+                display: flex;
+                flex-direction: column;
+                align-items: center;
+                justify-content: center;
+                height: 100vh;
+                margin: 0;
+                overflow: hidden;
+            }
+            canvas {
+                border: 1px solid white;
+                width: 100%;
+                height: 100%;
+                display: block;
+            }
+            button {
+                position: absolute;
+                bottom: 20px;
+                padding: 10px 20px;
+                font-size: 16px;
+                cursor: pointer;
+                background-color: #333;
+                color: white;
+                border: none;
+                border-radius: 5px;
+                z-index: 1;
+            }
+            #pauseResumeBtn {
+                left: 20px;
+            }
+            #speedBtn {
+                right: 20px;
+            }
+        </style>
+    </head>
+    <body>
+        <canvas></canvas>
+        <button id="pauseResumeBtn">Pause</button>
+        <button id="speedBtn">Speed: 1x</button>
+        <script src="main.js"></script>
+    </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -2,16 +2,33 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <title></title>  
+    <title>Pause/Resume Simulation</title>  
     <style>
         body {
             background-color: black;
+            color: white;
+            font-family: Arial, sans-serif;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: center;
+            height: 100vh;
+            margin: 0;
+        }
+        canvas {
+            border: 1px solid white;
+        }
+        button {
+            margin-top: 20px;
+            padding: 10px 20px;
+            font-size: 16px;
+            cursor: pointer;
         }
     </style>
 </head>
 <body>
-    <canvas>
-        <script src="main.js"></script>
-    </canvas>
+    <canvas></canvas>
+    <button id="pauseResumeBtn">Pause</button>
+    <script src="main.js"></script>
 </body>
 </html>

--- a/main.js
+++ b/main.js
@@ -1,16 +1,18 @@
-//initialize canvas
+// Initialize canvas
 var canvas = document.querySelector('canvas');
 var ctx = canvas.getContext('2d');
-//width&height
 var width = canvas.width = window.innerWidth;
 var height = canvas.height = window.innerHeight;
-//empty 
-let balls = []
+let balls = [];
+let animationId;
+let isPaused = false;
 
-function random(min,max) {
-  return Math.floor(Math.random()*(max-min)) + min;
+// Function to generate random numbers
+function random(min, max) {
+  return Math.floor(Math.random() * (max - min)) + min;
 }
 
+// Function to generate random colors
 function randomColor() {
   return 'rgb(' +
          random(0, 255) + ', ' +
@@ -18,74 +20,99 @@ function randomColor() {
          random(0, 255) + ')';
 }
 
-function Ball(x,y,velX,velY,color,size) {
-  this.x = x
-  this.y = y
-  this.velX = velX
-  this.velY = velY
-  this.color = color
-  this.size = size
+// Ball constructor
+function Ball(x, y, velX, velY, color, size) {
+  this.x = x;
+  this.y = y;
+  this.velX = velX;
+  this.velY = velY;
+  this.color = color;
+  this.size = size;
 }
 
-Ball.prototype.draw = function(){
-  ctx.beginPath()
+// Draw method for Ball
+Ball.prototype.draw = function() {
+  ctx.beginPath();
   ctx.fillStyle = this.color;
-  ctx.arc(this.x,this.y,this.size,0,2*Math.PI)
-  ctx.fill()
-}
+  ctx.arc(this.x, this.y, this.size, 0, 2 * Math.PI);
+  ctx.fill();
+};
 
-Ball.prototype.update = function(){
-  if((this.x+this.size)>=width){
+// Update method for Ball
+Ball.prototype.update = function() {
+  if ((this.x + this.size) >= width) {
     this.velX = -(this.velX);
   }
-  if((this.x - this.size)<=0){
+  if ((this.x - this.size) <= 0) {
     this.velX = -(this.velX);
   }
 
-  if((this.y+this.size)>=height){
+  if ((this.y + this.size) >= height) {
     this.velY = -(this.velY);
   }
-  if((this.y - this.size)<=0){
+  if ((this.y - this.size) <= 0) {
     this.velY = -(this.velY);
   }
-  this.x += this.velX
-  this.y += this.velY
-}
+  this.x += this.velX;
+  this.y += this.velY;
+};
 
-Ball.prototype.collisionDetect = function(){
-  for(let j=0;j<balls.length;j++){
-    let curBall = balls[j]
-    if( (this!==curBall) ){
+// Collision detection method for Ball
+Ball.prototype.collisionDetect = function() {
+  for (let j = 0; j < balls.length; j++) {
+    let curBall = balls[j];
+    if (this !== curBall) {
       var dx = this.x - curBall.x;
       var dy = this.y - curBall.y;
-      var distance = Math.sqrt(dx*dx + dy*dy)
+      var distance = Math.sqrt(dx * dx + dy * dy);
 
-      if(distance < this.size+ curBall.size){
-        curBall.color = this.color = randomColor()
+      if (distance < this.size + curBall.size) {
+        curBall.color = this.color = randomColor();
       }
     }
   }
-}
-function loop(){
+};
+
+// Animation loop
+function loop() {
   ctx.fillStyle = 'rgba(0, 0, 0, 0.25)';
   ctx.fillRect(0, 0, width, height);
-  while(balls.length<30){
+
+  while (balls.length < 30) {
     let ball = new Ball(
-      random(0,width),
-      random(0,height),
-      random(-7,7),
-      random(-7,7),
+      random(0, width),
+      random(0, height),
+      random(-7, 7),
+      random(-7, 7),
       randomColor(),
-      random(10,20)
-      )
-      balls.push(ball)
+      random(10, 20)
+    );
+    balls.push(ball);
   }
-  for(let i=0;i<balls.length;i++){
-    let ball = balls[i]
-    ball.draw()
-    ball.update()
-    ball.collisionDetect()
+
+  for (let i = 0; i < balls.length; i++) {
+    let ball = balls[i];
+    ball.draw();
+    ball.update();
+    ball.collisionDetect();
   }
-  requestAnimationFrame(loop)
+
+  if (!isPaused) {
+    animationId = requestAnimationFrame(loop);
+  }
 }
-loop()
+
+// Start the animation loop
+loop();
+
+// Toggle pause/resume
+document.getElementById('pauseResumeBtn').addEventListener('click', function() {
+  isPaused = !isPaused;
+  if (isPaused) {
+    cancelAnimationFrame(animationId);
+    this.textContent = 'Resume';
+  } else {
+    loop();
+    this.textContent = 'Pause';
+  }
+});

--- a/main.js
+++ b/main.js
@@ -1,105 +1,103 @@
 // Initialize canvas
-var canvas = document.querySelector('canvas');
-var ctx = canvas.getContext('2d');
-var width = canvas.width = window.innerWidth;
-var height = canvas.height = window.innerHeight;
+const canvas = document.querySelector('canvas');
+const ctx = canvas.getContext('2d');
+const width = canvas.width = window.innerWidth;
+const height = canvas.height = window.innerHeight;
 let balls = [];
 let animationId;
 let isPaused = false;
+let speedMultiplier = 1;
 
 // Function to generate random numbers
 function random(min, max) {
-  return Math.floor(Math.random() * (max - min)) + min;
+    return Math.floor(Math.random() * (max - min)) + min;
 }
 
 // Function to generate random colors
 function randomColor() {
-  return 'rgb(' +
-         random(0, 255) + ', ' +
-         random(0, 255) + ', ' +
-         random(0, 255) + ')';
+    return `rgb(${random(0, 255)}, ${random(0, 255)}, ${random(0, 255)})`;
 }
 
 // Ball constructor
 function Ball(x, y, velX, velY, color, size) {
-  this.x = x;
-  this.y = y;
-  this.velX = velX;
-  this.velY = velY;
-  this.color = color;
-  this.size = size;
+    this.x = x;
+    this.y = y;
+    this.velX = velX;
+    this.velY = velY;
+    this.color = color;
+    this.size = size;
 }
 
 // Draw method for Ball
 Ball.prototype.draw = function() {
-  ctx.beginPath();
-  ctx.fillStyle = this.color;
-  ctx.arc(this.x, this.y, this.size, 0, 2 * Math.PI);
-  ctx.fill();
+    ctx.beginPath();
+    ctx.fillStyle = this.color;
+    ctx.arc(this.x, this.y, this.size, 0, 2 * Math.PI);
+    ctx.fill();
 };
 
 // Update method for Ball
 Ball.prototype.update = function() {
-  if ((this.x + this.size) >= width) {
-    this.velX = -(this.velX);
-  }
-  if ((this.x - this.size) <= 0) {
-    this.velX = -(this.velX);
-  }
-
-  if ((this.y + this.size) >= height) {
-    this.velY = -(this.velY);
-  }
-  if ((this.y - this.size) <= 0) {
-    this.velY = -(this.velY);
-  }
-  this.x += this.velX;
-  this.y += this.velY;
+  /*this.velY += 0.1;  ADD GRAVITY, remove the commentary notation to test*/
+    if ((this.x + this.size) >= width) {
+        this.velX = -(this.velX);
+    }
+    if ((this.x - this.size) <= 0) {
+        this.velX = -(this.velX);
+    }
+    if ((this.y + this.size) >= height) {
+        this.velY = -(this.velY);
+    }
+    if ((this.y - this.size) <= 0) {
+        this.velY = -(this.velY);
+    }
+    this.x += this.velX * speedMultiplier;
+    this.y += this.velY * speedMultiplier;
 };
 
 // Collision detection method for Ball
 Ball.prototype.collisionDetect = function() {
-  for (let j = 0; j < balls.length; j++) {
-    let curBall = balls[j];
-    if (this !== curBall) {
-      var dx = this.x - curBall.x;
-      var dy = this.y - curBall.y;
-      var distance = Math.sqrt(dx * dx + dy * dy);
+    for (let j = 0; j < balls.length; j++) {
+        const curBall = balls[j];
+        if (this !== curBall) {
+            const dx = this.x - curBall.x;
+            const dy = this.y - curBall.y;
+            const distance = Math.sqrt(dx * dx + dy * dy);
 
-      if (distance < this.size + curBall.size) {
-        curBall.color = this.color = randomColor();
-      }
+            if (distance < this.size + curBall.size) {
+                curBall.color = this.color = randomColor();
+            }
+        }
     }
-  }
 };
 
 // Animation loop
 function loop() {
-  ctx.fillStyle = 'rgba(0, 0, 0, 0.25)';
-  ctx.fillRect(0, 0, width, height);
+    ctx.fillStyle = 'rgba(0, 0, 0, 0.25)';
+    ctx.fillRect(0, 0, width, height);
 
-  while (balls.length < 30) {
-    let ball = new Ball(
-      random(0, width),
-      random(0, height),
-      random(-7, 7),
-      random(-7, 7),
-      randomColor(),
-      random(10, 20)
-    );
-    balls.push(ball);
-  }
+    while (balls.length < 30) {
+        const ball = new Ball(
+            random(0, width),
+            random(0, height),
+            random(-7, 7),
+            random(-7, 7),
+            randomColor(),
+            random(10, 20)
+        );
+        balls.push(ball);
+    }
 
-  for (let i = 0; i < balls.length; i++) {
-    let ball = balls[i];
-    ball.draw();
-    ball.update();
-    ball.collisionDetect();
-  }
+    for (let i = 0; i < balls.length; i++) {
+        const ball = balls[i];
+        ball.draw();
+        ball.update();
+        ball.collisionDetect();
+    }
 
-  if (!isPaused) {
-    animationId = requestAnimationFrame(loop);
-  }
+    if (!isPaused) {
+        animationId = requestAnimationFrame(loop);
+    }
 }
 
 // Start the animation loop
@@ -107,12 +105,30 @@ loop();
 
 // Toggle pause/resume
 document.getElementById('pauseResumeBtn').addEventListener('click', function() {
-  isPaused = !isPaused;
-  if (isPaused) {
-    cancelAnimationFrame(animationId);
-    this.textContent = 'Resume';
-  } else {
-    loop();
-    this.textContent = 'Pause';
+    this.style.backgroundColor = '#555';
+      setTimeout(() => this.style.backgroundColor = '#333', 100); /* Visible button clicks*/
+    isPaused = !isPaused;
+    if (isPaused) {
+        cancelAnimationFrame(animationId);
+        this.textContent = 'Resume';
+    } else {
+        loop();
+        this.textContent = 'Pause';
+    }
+});
+
+// Toggle speed multiplier
+document.getElementById('speedBtn').addEventListener('click', function() {
+    this.style.backgroundColor = '#555'; 
+      setTimeout(() => this.style.backgroundColor = '#333', 100); /* Visible button clicks*/
+    if (speedMultiplier === 0.5) {
+        speedMultiplier = 1;
+        this.textContent = 'Speed: 1x';
+    } else if (speedMultiplier === 1) {
+        speedMultiplier = 2;
+        this.textContent = 'Speed: 2x';
+    } else if (speedMultiplier === 2) {
+        speedMultiplier = 0.5;
+        this.textContent = 'Speed: 0.5x';
   }
 });


### PR DESCRIPTION
This PR adds a pause/resume button to control the simulation.

It was tested and working in Firefox, Chrome, and Edge.

Changes include:

#### index.html

- Added a button element below the canvas.
- Added CSS styling for the button.

#### main.js

- Added global variables to manage the animation state.
- Modified the loop() function to respect the pause state.
- Added a click event listener to toggle pause/resume.

Closes #4  (if applicable).